### PR TITLE
dama18 lab2 bug fix for snitt

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -28,6 +28,8 @@ def filter_pairs(h, known_pairs):
         a, b = line.split()
         if (a,b) in known_pairs:
             n_shared += 1
+        if (b,a) in known_pairs:
+            n_shared += 1
         else:
             n_unique += 1
     return n_shared, n_unique

--- a/snitt.py
+++ b/snitt.py
@@ -28,7 +28,7 @@ def filter_pairs(h, known_pairs):
         a, b = line.split()
         if (a,b) in known_pairs:
             n_shared += 1
-        if (b,a) in known_pairs:
+        elif (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
When I tested the program using the smaller files as input, I noticed that the program does see the edges (a,c) and (c,a) as two different edges, even though the vertices represent the same edge. The program already has an if-statement to check if the vertices (a,b) are in known_pairs. My solution to fix the bug is to add an elif-statement to also check if the vertices (b,a) are in known_pairs.