### PR TITLE
corrected filter_pairs

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -26,7 +26,7 @@ def filter_pairs(h, known_pairs):
     n_unique = 0
     for line in h:
         a, b = line.split()
-        if (a,b) in known_pairs:
+        if (a,b) in known_pairs or (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
filter_pairs now counts (a,b) or (b,a) as shared-pairs. (if they are in known_pairs)