### PR TITLE
fix

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -28,6 +28,8 @@ def filter_pairs(h, known_pairs):
         a, b = line.split()
         if (a,b) in known_pairs:
             n_shared += 1
+        elif (b,a) in known_pairs:
+            n_shared += 1
         else:
             n_unique += 1
     return n_shared, n_unique


### PR DESCRIPTION
Problemet var att programmet tog hänsyn till ordningen i varje par, och missade därmed flera gemensamma par.
Eftersom file1 gjorts om till dictionary, verkade det enklast att bara ändra i funktionen som jämför varje rad i file2 med dictionary.