### PR TITLE
Räknar nu oordnade par istället för ordnade

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -26,7 +26,7 @@ def filter_pairs(h, known_pairs):
     n_unique = 0
     for line in h:
         a, b = line.split()
-        if (a,b) in known_pairs:
+        if (a,b) in known_pairs or (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
Pythonprogrammet räknar paren i filerna i den ordning den står. Det motsvarar att hantera grafen som en directed graph istället för en undirected graph. Ändringen här byter så att varje par blir oordnat istället för ordnat.  