### PR TITLE
filter_pairs now takes mirrored pairs into account (LAB2 bug fix)

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -28,6 +28,8 @@ def filter_pairs(h, known_pairs):
         a, b = line.split()
         if (a,b) in known_pairs:
             n_shared += 1
+        elif (b,a) in known_pairs:
+            n_shared += 1
         else:
             n_unique += 1
     return n_shared, n_unique


### PR DESCRIPTION
Added 'elif' in filter_pairs for counting mirrored pairs
elif (b,a) in known_pairs:
   n_shared += 1