### PR TITLE
Added check for commuted edge

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -26,7 +26,7 @@ def filter_pairs(h, known_pairs):
     n_unique = 0
     for line in h:
         a, b = line.split()
-        if (a,b) in known_pairs:
+        if (a,b) in known_pairs or (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
Since edges are undirected the edge (a,b) and (b,a) are the same - known_pairs only stores one of the two so both orders need to be checked. This is now done in filter_pairs. 