### PR TITLE
Fixed bug so that the order of pairs of vertices are not heeded

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -26,7 +26,7 @@ def filter_pairs(h, known_pairs):
     n_unique = 0
     for line in h:
         a, b = line.split()
-        if (a,b) in known_pairs:
+        if (a,b) in known_pairs or (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
Fixed bug so that the order of pairs of vertices are not heeded. 

Practice assignment in da3018